### PR TITLE
Fix RSS feeds

### DIFF
--- a/lib/weather_report.ex
+++ b/lib/weather_report.ex
@@ -73,10 +73,10 @@ defmodule WeatherReport do
             end)
   end
 
-@doc """
-Refresh cached stations.
-"""
-@spec refresh_stations() :: :ok
+  @doc """
+  Refresh cached stations.
+  """
+  @spec refresh_stations() :: :ok
   def refresh_stations() do
     :ok = GenServer.cast(StationRegistry, :refresh_list)
   end

--- a/lib/weather_report.ex
+++ b/lib/weather_report.ex
@@ -52,7 +52,6 @@ defmodule WeatherReport do
   end
 
   def get_forecast(station, type) do
-  require Logger
     url =
       case type do
         {:raw, subtype} when subtype in [:rss, :xml] ->
@@ -70,7 +69,6 @@ defmodule WeatherReport do
                 body
 
               _ ->
-                Logger.info(resp)
                 Forecast.parse(body, type)
             end)
   end

--- a/lib/weather_report/distance.ex
+++ b/lib/weather_report/distance.ex
@@ -10,11 +10,11 @@ defmodule WeatherReport.Distance do
 
   @doc """
   Calculates the distance (in meters) between two lat long coordinates by using the `haversine` forumla:
-
+  
       a = sin²(Δφ/2) + cos φ1 * cos φ2 * sin²(Δλ/2)
       c = 2 * atan2( √a, √(1−a) )
       d = R * c
-
+  
   where	φ is latitude, λ is longitude, R is earth’s radius (mean radius = 6,371km)  
   """
   @spec calc(coordinate, coordinate) :: float

--- a/lib/weather_report/forecast.ex
+++ b/lib/weather_report/forecast.ex
@@ -2,6 +2,7 @@ defmodule WeatherReport.Forecast do
   @moduledoc """
   Parse a document into a forecast.
   """
+  require Logger
 
   alias WeatherReport.Forecast.{RSS, XML}
 
@@ -11,6 +12,11 @@ defmodule WeatherReport.Forecast do
   Parses an rss or xml document into a forecast.
   """
   @spec parse(String.t(), :xml | :rss) :: {:ok, t} | {:error, String.t()}
+  def parse(~s(<?xml version="1.0" encoding="ISO-8859-1"?>) <> feed, :rss) do
+  Logger.info(feed)
+    parse(feed, :rss)
+  end
+
   def parse(feed, :rss) do
     {:ok, RSS.parse(feed)}
   end

--- a/lib/weather_report/forecast.ex
+++ b/lib/weather_report/forecast.ex
@@ -2,7 +2,6 @@ defmodule WeatherReport.Forecast do
   @moduledoc """
   Parse a document into a forecast.
   """
-  require Logger
 
   alias WeatherReport.Forecast.{RSS, XML}
 
@@ -13,7 +12,6 @@ defmodule WeatherReport.Forecast do
   """
   @spec parse(String.t(), :xml | :rss) :: {:ok, t} | {:error, String.t()}
   def parse(~s(<?xml version="1.0" encoding="ISO-8859-1"?>) <> feed, :rss) do
-    Logger.info(feed)
     parse(feed, :rss)
   end
 

--- a/lib/weather_report/forecast.ex
+++ b/lib/weather_report/forecast.ex
@@ -13,7 +13,7 @@ defmodule WeatherReport.Forecast do
   """
   @spec parse(String.t(), :xml | :rss) :: {:ok, t} | {:error, String.t()}
   def parse(~s(<?xml version="1.0" encoding="ISO-8859-1"?>) <> feed, :rss) do
-  Logger.info(feed)
+    Logger.info(feed)
     parse(feed, :rss)
   end
 

--- a/lib/weather_report/forecast/rss.ex
+++ b/lib/weather_report/forecast/rss.ex
@@ -24,6 +24,7 @@ defmodule WeatherReport.Forecast.RSS do
     case :feeder.stream(feed, RSSParser.opts()) do
       {:ok, [entry], ""} ->
         entry
+
       _ ->
         %__MODULE__{}
     end

--- a/lib/weather_report/forecast/rss.ex
+++ b/lib/weather_report/forecast/rss.ex
@@ -7,13 +7,13 @@ defmodule WeatherReport.Forecast.RSS do
   defstruct timestamp: nil,
             link: nil,
             html_summary: nil,
-            text: nil
+            title: nil
 
   @type t :: %__MODULE__{
           timestamp: String.t(),
           link: String.t(),
           html_summary: String.t(),
-          text: String.t()
+          title: String.t()
         }
 
   @doc """
@@ -22,14 +22,8 @@ defmodule WeatherReport.Forecast.RSS do
   @spec parse(String.t()) :: t
   def parse(feed) do
     case :feeder.stream(feed, RSSParser.opts()) do
-      {:ok, %{entries: [entry]}, ""} ->
-        %__MODULE__{
-          timestamp: entry.id,
-          link: entry.link,
-          html_summary: entry.summary,
-          text: entry.title
-        }
-
+      {:ok, [entry], ""} ->
+        entry
       _ ->
         %__MODULE__{}
     end

--- a/lib/weather_report/rss_parser.ex
+++ b/lib/weather_report/rss_parser.ex
@@ -1,11 +1,11 @@
 defmodule WeatherReport.RSSParser do
   @moduledoc false
 
-alias WeatherReport.Forecast.RSS
+  alias WeatherReport.Forecast.RSS
 
   @doc false
   def event(
-        {:feed, _ },
+        {:feed, _},
         {_, entries}
       ) do
     # Don't care about feed.
@@ -14,15 +14,20 @@ alias WeatherReport.Forecast.RSS
 
   def event(
         {:entry,
-         {:entry, _author, _categories, _duration, _enclosure, id, _image, link, _subtitle, summary, title, _updated}},
+         {:entry, _author, _categories, _duration, _enclosure, id, _image, link, _subtitle,
+          summary, title, _updated}},
         {_, entries}
       ) do
-    {nil, [%RSS{
-      timestamp: undefined_to_nil(id),
-      link: undefined_to_nil(link),
-      html_summary: undefined_to_nil(summary),
-      title: undefined_to_nil(title),
-    }|entries]}
+    {nil,
+     [
+       %RSS{
+         timestamp: undefined_to_nil(id),
+         link: undefined_to_nil(link),
+         html_summary: undefined_to_nil(summary),
+         title: undefined_to_nil(title)
+       }
+       | entries
+     ]}
   end
 
   def event(:endFeed, {_, entries}) do

--- a/lib/weather_report/rss_parser.ex
+++ b/lib/weather_report/rss_parser.ex
@@ -1,12 +1,14 @@
 defmodule WeatherReport.RSSParser do
   @moduledoc false
   # https://github.com/manukall/feeder_ex/blob/master/lib/feeder_ex/parser.ex
+  require Logger
 
   @doc false
   def event(
-        {:feed, {:feed, author, id, image, language, link, subtitle, summary, title, updated}},
+        {:feed, {:feed, author, id, image, language, link, subtitle, summary, title, updated} = e},
         {_, entries}
       ) do
+      Logger.info(e)
     feed = %{
       author: undefined_to_nil(author),
       id: undefined_to_nil(id),
@@ -24,9 +26,10 @@ defmodule WeatherReport.RSSParser do
 
   def event(
         {:entry,
-         {:entry, author, duration, enclosure, id, image, link, subtitle, summary, title, updated}},
+         {:entry, author, duration, enclosure, id, image, link, subtitle, summary, title, updated}=e},
         {feed, entries}
       ) do
+      Logger.info(e)
     entry = %{
       author: undefined_to_nil(author),
       duration: undefined_to_nil(duration),

--- a/lib/weather_report/rss_parser.ex
+++ b/lib/weather_report/rss_parser.ex
@@ -1,7 +1,5 @@
 defmodule WeatherReport.RSSParser do
   @moduledoc false
-  # https://github.com/manukall/feeder_ex/blob/master/lib/feeder_ex/parser.ex
-  require Logger
 
 alias WeatherReport.Forecast.RSS
 

--- a/lib/weather_report/rss_parser.ex
+++ b/lib/weather_report/rss_parser.ex
@@ -3,51 +3,32 @@ defmodule WeatherReport.RSSParser do
   # https://github.com/manukall/feeder_ex/blob/master/lib/feeder_ex/parser.ex
   require Logger
 
+alias WeatherReport.Forecast.RSS
+
   @doc false
   def event(
-        {:feed, {:feed, author, id, image, language, link, subtitle, summary, title, updated} = e},
+        {:feed, _ },
         {_, entries}
       ) do
-      Logger.info(e)
-    feed = %{
-      author: undefined_to_nil(author),
-      id: undefined_to_nil(id),
-      image: undefined_to_nil(image),
-      language: undefined_to_nil(language),
-      link: undefined_to_nil(link),
-      subtitle: undefined_to_nil(subtitle),
-      summary: undefined_to_nil(summary),
-      title: undefined_to_nil(title),
-      updated: undefined_to_nil(updated)
-    }
-
-    {feed, entries}
+    # Don't care about feed.
+    {nil, entries}
   end
 
   def event(
         {:entry,
-         {:entry, author, duration, enclosure, id, image, link, subtitle, summary, title, updated}=e},
-        {feed, entries}
+         {:entry, author, categories, duration, enclosure, id, image, link, subtitle, summary, title, updated}=e},
+        {_, entries}
       ) do
-      Logger.info(e)
-    entry = %{
-      author: undefined_to_nil(author),
-      duration: undefined_to_nil(duration),
-      enclosure: parse_enclosure(enclosure),
-      id: undefined_to_nil(id),
-      image: undefined_to_nil(image),
+    {nil, [%RSS{
+      timestamp: undefined_to_nil(id),
       link: undefined_to_nil(link),
-      subtitle: undefined_to_nil(subtitle),
-      summary: undefined_to_nil(summary),
+      html_summary: undefined_to_nil(summary),
       title: undefined_to_nil(title),
-      updated: undefined_to_nil(updated)
-    }
-
-    {feed, [entry | entries]}
+    }|entries]}
   end
 
-  def event(:endFeed, {feed, entries}) do
-    Map.put(feed, :entries, Enum.reverse(entries))
+  def event(:endFeed, {_, entries}) do
+    Enum.reverse(entries)
   end
 
   @doc false
@@ -57,14 +38,4 @@ defmodule WeatherReport.RSSParser do
 
   defp undefined_to_nil(:undefined), do: nil
   defp undefined_to_nil(value), do: value
-
-  defp parse_enclosure(:undefined), do: nil
-
-  defp parse_enclosure({:enclosure, url, size, type}) do
-    %{
-      url: undefined_to_nil(url),
-      size: undefined_to_nil(size),
-      type: undefined_to_nil(type)
-    }
-  end
 end

--- a/lib/weather_report/rss_parser.ex
+++ b/lib/weather_report/rss_parser.ex
@@ -14,7 +14,7 @@ alias WeatherReport.Forecast.RSS
 
   def event(
         {:entry,
-         {:entry, author, categories, duration, enclosure, id, image, link, subtitle, summary, title, updated}=e},
+         {:entry, _author, _categories, _duration, _enclosure, id, _image, link, _subtitle, summary, title, _updated}},
         {_, entries}
       ) do
     {nil, [%RSS{

--- a/lib/weather_report/station.ex
+++ b/lib/weather_report/station.ex
@@ -46,11 +46,25 @@ defmodule WeatherReport.Station do
     |> Stream.map(&station_xmapper/1)
     |> Stream.map(&update_coordinate(&1, :latitude))
     |> Stream.map(&update_coordinate(&1, :longitude))
+    |> Stream.map(&update_feed_urls/1)
     |> Stream.map(&struct(__MODULE__, &1))
     |> Enum.to_list()
   end
 
   defp station_xmapper({:station, doc}), do: SweetXml.xmap(doc, @xmap)
+
+  defp update_feed_urls(station) do
+  station
+  |> Map.update!(:rss_url, &append_subdomain/1)
+  |> Map.update!(:xml_url, &append_subdomain/1)
+  end
+
+  defp append_subdomain(feed_url) do
+    URI.parse(feed_url)
+    |> Map.update!(:host, &("w1." <> &1))
+    |> Map.update!(:authority, &("w1." <> &1))
+    |> URI.to_string()
+  end
 
   defp update_coordinate(station, key), do: Map.update!(station, key, &parse_coordinate/1)
 

--- a/lib/weather_report/station.ex
+++ b/lib/weather_report/station.ex
@@ -54,9 +54,9 @@ defmodule WeatherReport.Station do
   defp station_xmapper({:station, doc}), do: SweetXml.xmap(doc, @xmap)
 
   defp update_feed_urls(station) do
-  station
-  |> Map.update!(:rss_url, &append_subdomain/1)
-  |> Map.update!(:xml_url, &append_subdomain/1)
+    station
+    |> Map.update!(:rss_url, &append_subdomain/1)
+    |> Map.update!(:xml_url, &append_subdomain/1)
   end
 
   defp append_subdomain(feed_url) do

--- a/lib/weather_report/station_registry.ex
+++ b/lib/weather_report/station_registry.ex
@@ -1,5 +1,4 @@
 defmodule WeatherReport.StationRegistry do
-
   @moduledoc false
   use GenServer
   alias WeatherReport.{Station, Distance}
@@ -29,7 +28,7 @@ defmodule WeatherReport.StationRegistry do
   :by_state
   :nearest
     Calculates the distance between a point and all of the stations, and returns the nearest one.
-
+  
   or :all for full list
   """
   def handle_call({:by_station_id, station_id}, _from, tab) do
@@ -70,17 +69,15 @@ defmodule WeatherReport.StationRegistry do
     {:reply, results, tab}
   end
 
-
-
   @doc """
   Wipes the station list from ets and re-retrieves it.
   """
   def handle_cast(:refresh_list, tab) do
-  true = :ets.delete_all_objects(tab)
-  {:noreply, tab, {:continue, :get_list}}
+    true = :ets.delete_all_objects(tab)
+    {:noreply, tab, {:continue, :get_list}}
   end
 
-    @doc """
+  @doc """
   Retrieves the station list and inserts it into ets.
   """
   def handle_continue(:get_list, tab) do

--- a/lib/weather_report/station_registry.ex
+++ b/lib/weather_report/station_registry.ex
@@ -18,8 +18,7 @@ defmodule WeatherReport.StationRegistry do
   """
   def init([]) do
     tab = :ets.new(:station_registry, [:private])
-    send(self(), :get_list)
-    {:ok, tab}
+    {:ok, tab, {:continue, :get_list}}
   end
 
   @doc """
@@ -71,10 +70,20 @@ defmodule WeatherReport.StationRegistry do
     {:reply, results, tab}
   end
 
+
+
   @doc """
+  Wipes the station list from ets and re-retrieves it.
+  """
+  def handle_cast(:refresh_list, tab) do
+  true = :ets.delete_all_objects(tab)
+  {:noreply, tab, {:continue, :get_list}}
+  end
+
+    @doc """
   Retrieves the station list and inserts it into ets.
   """
-  def handle_info(:get_list, tab) do
+  def handle_continue(:get_list, tab) do
     entries =
       Station.station_list()
       |> Enum.map(fn station ->

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule WeatherReport.Mixfile do
     [
       app: :weather_report,
       version: "0.3.0",
-      elixir: "~> 1.13",
+      elixir: "~> 1.12",
       description: description(),
       package: package(),
       deps: deps()

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule WeatherReport.Mixfile do
   defp description do
     """
     Get weather forecasts from the National Oceanic and Atmospheric Administration!
-
+    
     As the NOAA is a United States government agency, only forecasts in the US are supported.
     """
   end


### PR DESCRIPTION
Fixed RSS feeds, turns out the gov actually made some changes over the last 7 years 🙀 
Changes were:

* Subdomain required for rss feeds. Only rss, kinda weird since they give the xml link with the subdomain but it still works without it. Big XML must have powerful lobbyists.
* They put an xml header or something on the rss feed and feeder wouldn't take it. Idk if thats valid xml, I've literally never had to use xml.
* RSS schema changed slightly

```elixir
iex(74)> WeatherReport.get_forecast(station.station_id, :rss)
{:ok,
 %WeatherReport.Forecast.RSS{
   timestamp: "Sat, 15 Apr 2023 10:53:00 -0500",
   link: "https://w1.weather.gov/data/obhistory/KMDW.html",
   html_summary: "<img src=\"https://forecast.weather.gov/images/wtf/small/bkn.png\" class=\"noaaWeatherIcon\"  width=\"55\" height=\"58\" alt=\"Mostly Cloudy\" style=\"float:left;\" /><br />\nWinds are South at 9.2 MPH (8 KT). The pressure is 1007.8 mb and the humidity is 46%.\n Last Updated on Apr 15 2023, 10:53 am CDT.",
   title: "Mostly Cloudy and 75 F at Chicago, Chicago Midway Airport, IL"
 }}
```